### PR TITLE
Fix text encoding issue for CDN

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,15 +29,14 @@ jobs:
           folder: dist
 
       - name: Deploy (S3)
-        uses: jakejarvis/s3-sync-action@master
+        uses: emmiegit/s3-sync-action@main
         with:
-          args: --content-encoding utf-8 --delete
+          args: --delete
         env:
           AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
           AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_CLI_FILE_ENCODING: UTF-8
           SOURCE_DIR: dist
           DEST_DIR: ${{ env.BUCKET_PATH }}
 


### PR DESCRIPTION
(See https://github.com/scpwiki/sigma/pull/86, description copied from there)

One known issue with `cdn.scpwiki.com` has been the incorrect application of charsets onto uploaded files, causing any non-ASCII characters to render incorrectly.

This is tracked in https://github.com/aws/aws-cli/issues/1346. It seems clear that Amazon is not going to release a fix, so I have created https://github.com/emmiegit/s3-sync-action. This new action is a script which uploads each file separately, allowing us to detect and specify the MIME explicitly. This should fix the encoding issue and allow us to prepare to use the CDN for real.

I tested this using the dummy `scp-wiki-cdn-test` bucket, and confirmed that the expected file layout was present.